### PR TITLE
refactor: use w3id terms for extension itself

### DIFF
--- a/extensions/shacl/index.bs
+++ b/extensions/shacl/index.bs
@@ -4,7 +4,7 @@ Shortname: hashi
 Level: 1
 Status: LD
 Group: HydraCG
-URL: https://hydracg.github.io/extensions/shacl
+URL: https://w3id.org/hydra/extension/shacl
 Editor: Tomasz Pluskiewicz, Zazuko GmbH https://zazuko.com/, https://t-code.pl
 Abstract: This document provides additional terms and examples of using SHACL together with Hydra to describe API's hyperemedia
 Markup Shorthands: markdown yes
@@ -34,9 +34,11 @@ In this document we propose various ways in which [[SHACL]] can be used by both 
 
 # Conventions # {#conventions}
 
-The base namespace of this extension and its unique identifier is `http://www.w3.org/ns/hydra/shacl#`.
+The base namespace of extensions is `https://w3id.org/hydra/extension#`.
 
-The preferred prefix is `hashi:`.
+The preferred prefix is `hex:`.
+
+The unique identifier of the SHACL extension is `https://w3id.org/hydra/extension#shacl`
 
 #  Announcing the extension # {#announcing}
 
@@ -51,7 +53,7 @@ Conforming with the [[Hydra#extensions|Extensions]] section of [[Hydra]], an API
 {
   "@context": "http://www.w3.org/ns/hydra/context.jsonld",
   "@id": "http://api.example.com/doc/",
-  "extension": "http://www.w3.org/ns/shacl#"
+  "extension": "https://w3id.org/hydra/extension#shacl"
 }
 </pre>
 </div>

--- a/extensions/shacl/vocab.ttl
+++ b/extensions/shacl/vocab.ttl
@@ -1,0 +1,7 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix hex: <https://w3id.org/hydra/extension#>
+
+hex:shacl
+    rdfs:label "SHACL extension for Hydra Core vocabulary" ;
+    rdfs:seeAlso <https://w3id.org/hydra/extension/shacl> ;
+.


### PR DESCRIPTION
Drafting this until we 100% decide on #7 

This exercise the idea to have a single namespace `prefix hex: <https://w3id.org/hydra/extension#>` for all terms and in fact introduces the first one to identify the SHACL extension itself: `hex:shacl`