### PR TITLE
feat: build single RDF source of extensions combined

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker-practice/actions-setup-docker@1.0.4
     - run: make build
+    - run: make build-vocabulary
     - name: GitHub Pages
       if: ${{ github.ref == 'refs/heads/master' }}
       uses: crazy-max/ghaction-github-pages@v2.1.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 index.html
+extensions/*[.ttl, .nt, .rdf, .jsonld]

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,8 @@ build:
 new:
 	mkdir -p ./extensions/$(spec)
 	docker-compose run --rm bikeshed template > ./extensions/$(spec)/index.bs
+
+build-vocabulary:
+	npx graphy read -c ttl / concat / tree / write -c nt --inputs extensions/*/vocab.ttl > extensions/extensions.nt
+	npx graphy read -c ttl / concat / tree / write -c ttl --inputs extensions/*/vocab.ttl > extensions/extensions.ttl
+	npx graphy read -c ttl / concat / tree / scribe -c xml --inputs extensions/*/vocab.ttl > extensions/extensions.rdf

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,4 @@ build-vocabulary:
 	npx graphy read -c ttl / concat / tree / write -c nt --inputs extensions/*/vocab.ttl > extensions/extensions.nt
 	npx graphy read -c ttl / concat / tree / write -c ttl --inputs extensions/*/vocab.ttl > extensions/extensions.ttl
 	npx graphy read -c ttl / concat / tree / scribe -c xml --inputs extensions/*/vocab.ttl > extensions/extensions.rdf
+	cat extensions/*/vocab.ttl | npx @frogcat/ttl2jsonld > extensions/extensions.jsonld


### PR DESCRIPTION
This finds all `extensions/*/vocab.ttl` and output them combined in 4 serialisations