### PR TITLE
Unrecognized spec references in OWL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,12 @@ jobs:
       with:
         node-version: 14
     - run: make build
+    - name: Check all built
+      run: |
+        NUM_BS=$(find extensions/*/ -name "index.bs" | wc -l);
+        NUM_HTML=$(find extensions/*/ -name "index.html" | wc -l);
+        [[ NUM_BS -eq NUM_HTML ]] || (echo "$(expr $NUM_BS - $NUM_HTML) bikeshed not built" && exit 1)
+        
     - run: make build-vocabulary
     - name: GitHub Pages
       if: ${{ github.ref == 'refs/heads/master' }}

--- a/extensions/hydra-in-owl/index.bs
+++ b/extensions/hydra-in-owl/index.bs
@@ -26,11 +26,11 @@ Abstract: Hydra terms extensively described with Web Ontology Language (OWL).
 Introduction {#intro}
 =====================
 
-This extensions describes [[!Hydra|Hydra Core Vocabulary]] terms using [[!OWL|Web Ontology Language]] (OWL).
+This extensions describes [[!Hydra|Hydra Core Vocabulary]] terms using [[!owl2-overview|Web Ontology Language]] (OWL).
 It neither present any new Hydra terms nor replaces any existing definitions. It SHOULD be used in conjunction with the
 [[!Hydra|Hydra Core Vocabulary]] specification as it is a complementary specification.
 
-It's purpose is purely to describe all the terms with pure [[!RDFS|Resource Description Framework Schema]] (RDFS) and
-[[!OWL|Web Ontology Language]] (OWL) ontologies so is is possible to either validate hydra constructs or use it with
+It's purpose is purely to describe all the terms with pure [[!rdf-schema|Resource Description Framework Schema]] (RDFS) and
+[[!owl2-overview|Web Ontology Language]] (OWL) ontologies so is is possible to either validate hydra constructs or use it with
 RDF reasoners.
 


### PR DESCRIPTION
I added a step after bikeshed runs to check that all specs are successfully generated. It reveals a problem with OWL which I also fix here